### PR TITLE
Updated UART testing to use UART2 instead of UART1

### DIFF
--- a/tests/RemoteWeatherStation/README.txt
+++ b/tests/RemoteWeatherStation/README.txt
@@ -1,16 +1,16 @@
-Remote Weather Station Test is a device interface test for the UART1 on the beaglebone.  
+Remote Weather Station Test is a device interface test for the UART2 on the beaglebone.  
 
 Components are 
-* WeatherReporter - includes UART1 interface for reading and writing
+* WeatherReporter - includes UART2 interface for reading and writing
 * WeatherListener - listens for the reporter data read and acknowledges the existence
 
-The WeatherReporter will open the UART1 port and read the input when data arrives. It then publishes the DataFrame. 
+The WeatherReporter will open the UART2 port and read the input when data arrives. It then publishes the DataFrame. 
 WeatherListener subscribes to the DataFrame message and when a new message is received, it will publish an acknowledgement (DataAck = "OKAY, got it!").
 The WeatherReporter listens for the DataAck and writes that message out to the UART port.
 
 UART Configuration
 ------------------
-port = '/dev/ttyO1'
+port = '/dev/ttyO2'
 baud rate = 115200
 8 bit, parity = None, 1 stopbit   
 timeout = 0, so it does not block 
@@ -20,7 +20,7 @@ HW notes on testing this
 Tools used:  
 * Terminal tool on the host
 * USB to 3.3 V TTL Cable (TTL-232R-3V3 by FTDI Chip) 
-    - How to connect with BBB (P9 connector):  White (RX) to BBB TX (pin 24), Green (TX) to BBB RX (pin 26), GND on BBB pins 1, 2, 45, 46
+    - How to connect with BBB (P9 connector):  White (RX) to BBB TX (pin 21), Green (TX) to BBB RX (pin 22), GND on BBB pins 1, 2, 45, 46
 
 Library used:
 * pySerial used for UART communication
@@ -39,24 +39,24 @@ Configuration needed on the BBB image (to be updated in a future image)
     $ sudo usermod -a -G dialout riaps
     $ sudo usermod -a -G dialout riapsdev
 
-To turn on the UART1, modify /boot/uEnv.txt by uncommenting the following line and adding BB-UART1 (which points to an overlay in /lib/firmware)
+To turn on the UART2, modify /boot/uEnv.txt by uncommenting the following line and adding BB-UART2 (which points to an overlay in /lib/firmware)
 	#Example v4.1.x
 	#cape_disable=bone_capemgr.disable_partno=
-	cape_enable=bone_capemgr.enable_partno=BB-UART1
+	cape_enable=bone_capemgr.enable_partno=BB-UART2
 	
-Reboot the beaglebone to see the UART1 enabled. UART1 device is setup as ttyO1 (where the fourth letter is the letter 'O', no zero) 
-that references ttyS1 (a special character files)
+Reboot the beaglebone to see the UART2 enabled. UART2 device is setup as ttyO2 (where the fourth letter is the letter 'O', no zero) 
+that references ttyS2 (a special character files)
 
-To verify that UART1 is enabled, do the following:
+To verify that UART2 is enabled, do the following:
 $ cat $SLOTS
  0: PF----  -1 
  1: PF----  -1 
  2: PF----  -1 
  3: PF----  -1 
- 4: P-O-L-   0 Override Board Name,00A0,Override Manuf,BB-UART1
+ 4: P-O-L-   0 Override Board Name,00A0,Override Manuf,BB-UART2
  
 $ ls -l /dev/ttyO*
 lrwxrwxrwx 1 root root 5 Mar  6 22:54 /dev/ttyO0 -> ttyS0
-lrwxrwxrwx 1 root root 5 Mar  6 22:54 /dev/ttyO1 -> ttyS1
+lrwxrwxrwx 1 root root 5 Mar  6 22:54 /dev/ttyO2 -> ttyS2
 
 

--- a/tests/RemoteWeatherStation/WeatherReporter.py
+++ b/tests/RemoteWeatherStation/WeatherReporter.py
@@ -71,10 +71,10 @@ class WReporterThread(threading.Thread):
 #                pydevd.settrace(host="192.168.1.103",port=5678) #MM TODO:  for debugging
                 if bytesToRead != 0:
                     try:
-                        self.component.logger.info("WReporterThread - read UART1, %d bytes",bytesToRead)
+                        self.component.logger.info("WReporterThread - read UART, %d bytes",bytesToRead)
                         data = self.ser.read(bytesToRead) 
                     except serial.SerialException:
-                        self.component.logger.error("WReporterThread - UART1 reading error: %s",serial.SerialException.strerror)           
+                        self.component.logger.error("WReporterThread - UART reading error: %s",serial.SerialException.strerror)           
                         self.ser.close()
                         break                   
                                         
@@ -100,7 +100,7 @@ class WReporterThread(threading.Thread):
         self.terminated.set()
 
 class WeatherReporter(Component):
-    def __init__(self, port="ttyO1", baudrate=115200, bytesize=serial.EIGHTBITS, parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE, serialTimeout=0):
+    def __init__(self, port="ttyO2", baudrate=115200, bytesize=serial.EIGHTBITS, parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE, serialTimeout=0):
         super().__init__()
         self.logger.setLevel(logging.DEBUG)
         self.pid = os.getpid()

--- a/tests/RemoteWeatherStation/wstation.riaps
+++ b/tests/RemoteWeatherStation/wstation.riaps
@@ -1,11 +1,11 @@
 // RIAPS Remote Weather Station (RWS) Demo
 
 app RemoteWeatherStation {
-    message DataFrame; // data received from UART1
-    message DataAck;   // writing message out UART1 (just to test writing capability)
+    message DataFrame; // data received from UART2
+    message DataAck;   // writing message out UART2 (just to test writing capability)
      
-	// Weather Station device interface - UART1
-    device WeatherReporter(port='ttyO1', baudrate=115200) {
+	// Weather Station device interface - UART2
+    device WeatherReporter(port='ttyO2', baudrate=115200) {
       // Inside port for forwarding messages coming from an internal thread.
       // The 'default' is optional, it implies a 1 sec timer/ticker thread.
       inside dataIn_queue; 	 // Receive data from UART1 and send to component
@@ -27,7 +27,7 @@ app RemoteWeatherStation {
     actor RemoteWeatherStationActor() {
        local DataFrame, DataAck;	// Local message types
        {
-       	  reporter : WeatherReporter(port='ttyO1', baudrate=115200);
+       	  reporter : WeatherReporter(port='ttyO2', baudrate=115200);
           listener : WeatherListener(); 		
        }
     }


### PR DESCRIPTION
Followup of change made for Modbus Testing, due to interference with ChronoCape UART1 usage.