### PR TITLE
Bump versions

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,4 @@
-export externalsversion="0.4.1" 
-export coreversion="0.4"
-export pycomversion="0.4.1"
+export externalsversion="0.4.2" 
+export coreversion="0.4.3"
+export pycomversion="0.4.2"
 


### PR DESCRIPTION
Updated version numbers: 

RIAPS Externals: 0.4.1 -> 0.4.2
RIAPS Core: 0.4 -> 0.4.3
RIAPS Pycom: 0.4.1 -> 0.4.2