### PR TITLE
Removing duplication of package installation.  The requirements liste…

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -21,10 +21,13 @@ setup(name='riaps-pycom',
         "scripts/riaps_actor", "scripts/riaps_ctrl", "scripts/riaps_deplo", "scripts/riaps_disco", "scripts/riaps_lang", "scripts/riaps_depll", "scripts/riaps_device", "scripts/riaps_devm"
 
      ],
-      install_requires=['rpyc>=3.3.1','textX == 1.5.1','redis >= 2.10.5','hiredis >= 0.2.0','pyzmq >= 16','pycapnp >= 0.5.9','netifaces >= 0.10.5','paramiko >= 2.0.2','cryptography >= 1.5.3', 'Adafruit_BBIO >= 1.0.3'],
-dependency_links=[
-        "git+https://github.com/adubey14/rpyc#egg=rpyc-3.3.1"
-    ],
+     
+     # These packages will be installed as part of the deb package for riaps-pycom.  Some of these packages are not installed on the armhf architecture.
+     # The deb package has specific instructions for amd64 and armhf. If you are installing this without using the deb package, be aware that more may be installed than necessary.  Also be
+     # aware that these requirements will change over time and are not being updated here (it is duplication).
+     # install_requires=['rpyc>=3.3.1','textX == 1.5.1','redis >= 2.10.5','hiredis >= 0.2.0','pyzmq >= 16','pycapnp >= 0.5.9','netifaces >= 0.10.5','paramiko >= 2.0.2','cryptography >= 1.5.3', 'Adafruit_BBIO >= 1.0.3'],
+     # dependency_links=["git+https://github.com/adubey14/rpyc#egg=rpyc-3.3.1"],
+     
       zip_safe=False)
 
  


### PR DESCRIPTION
…d in setup.py overlap with the postinst commands given in the deb package installation.  The deb package installation provides a way to have different sets for amd64 and armhf architectures.