### PR TITLE
Updated launch examples to point to the correct location (instead of …

### DIFF
--- a/launch examples/riaps ctrl.launch
+++ b/launch examples/riaps ctrl.launch
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramLaunchConfigurationType">
 <mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="RIAPSHOME" value="${env_var:HOME}/.local/riaps"/>
+<mapEntry key="RIAPSHOME" value="${env_var:HOME}/usr/local/riaps"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/.local/bin/riaps_ctrl"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/usr/local/bin/riaps_ctrl"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="-p 8888"/>
 </launchConfiguration>

--- a/launch examples/riaps dbase start.launch
+++ b/launch examples/riaps dbase start.launch
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramLaunchConfigurationType">
 <mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="RIAPSHOME" value="${env_var:HOME}/.local/riaps"/>
+<mapEntry key="RIAPSHOME" value="${env_var:HOME}/usr/local/riaps"/>
 </mapAttribute>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="/usr/local/bin/redis-server"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="${env_var:HOME}/.local/riaps/etc/redis.conf"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${env_var:HOME}/.local/riaps/etc"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="${env_var:HOME}/usr/local/riaps/etc/redis.conf"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${env_var:HOME}/usr/local/riaps/etc"/>
 </launchConfiguration>

--- a/launch examples/riaps dbase stop.launch
+++ b/launch examples/riaps dbase stop.launch
@@ -2,5 +2,5 @@
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramLaunchConfigurationType">
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="/usr/local/bin/redis-cli"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="shutdown"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${env_var:HOME}/.local/riaps/etc"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${env_var:HOME}/usr/local/riaps/etc"/>
 </launchConfiguration>

--- a/launch examples/riaps depll.launch
+++ b/launch examples/riaps depll.launch
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramLaunchConfigurationType">
 <mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="RIAPSHOME" value="${env_var:HOME}/.local/riaps"/>
+<mapEntry key="RIAPSHOME" value="${env_var:HOME}/usr/local/riaps"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/.local/bin/riaps_depll"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/usr/local/bin/riaps_depll"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="sample.depl"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${workspace_loc:/DistributedEstimator}"/>
 </launchConfiguration>

--- a/launch examples/riaps deplo.launch
+++ b/launch examples/riaps deplo.launch
@@ -2,8 +2,8 @@
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramLaunchConfigurationType">
 <mapAttribute key="org.eclipse.debug.core.environmentVariables">
 <mapEntry key="RIAPSAPPS" value="${env_var:HOME}/riaps_apps"/>
-<mapEntry key="RIAPSHOME" value="${env_var:HOME}/.local/riaps"/>
+<mapEntry key="RIAPSHOME" value="${env_var:HOME}/usr/local/riaps"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/.local/bin/riaps_deplo"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/usr/local/bin/riaps_deplo"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="-n localhost -p 8888"/>
 </launchConfiguration>

--- a/launch examples/riaps devm.launch
+++ b/launch examples/riaps devm.launch
@@ -2,7 +2,7 @@
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramLaunchConfigurationType">
 <mapAttribute key="org.eclipse.debug.core.environmentVariables">
 <mapEntry key="RIAPSAPPS" value="${env_var:HOME}/riaps_apps"/>
-<mapEntry key="RIAPSHOME" value="${env_var:HOME}/.local/riaps"/>
+<mapEntry key="RIAPSHOME" value="${env_var:HOME}/usr/local/riaps"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/.local/bin/riaps_devm"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/usr/local/bin/riaps_devm"/>
 </launchConfiguration>

--- a/launch examples/riaps disco.launch
+++ b/launch examples/riaps disco.launch
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramLaunchConfigurationType">
 <mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="RIAPSHOME" value="${env_var:HOME}/.local/riaps"/>
+<mapEntry key="RIAPSHOME" value="${env_var:HOME}/usr/local/riaps"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/.local/bin/riaps_disco"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/usr/local/bin/riaps_disco"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="--database localhost:6379"/>
 </launchConfiguration>

--- a/launch examples/riaps lang.launch
+++ b/launch examples/riaps lang.launch
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramLaunchConfigurationType">
 <mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="RIAPSHOME" value="${env_var:HOME}/.local/riaps"/>
+<mapEntry key="RIAPSHOME" value="${env_var:HOME}/usr/local/riaps"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/.local/bin/riaps_lang"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/usr/local/bin/riaps_lang"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="sample.riaps  -v"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${env_var:HOME}/riaps_apps/DistributedEstimator"/>
 </launchConfiguration>

--- a/launch examples/riaps run Aggregator.launch
+++ b/launch examples/riaps run Aggregator.launch
@@ -2,9 +2,9 @@
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramLaunchConfigurationType">
 <mapAttribute key="org.eclipse.debug.core.environmentVariables">
 <mapEntry key="RIAPSAPPS" value="${env_var:HOME}/riaps_apps"/>
-<mapEntry key="RIAPSHOME" value="${env_var:HOME}/.local/riaps"/>
+<mapEntry key="RIAPSHOME" value="${env_var:HOME}/usr/local/riaps"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/.local/bin/riaps_actor"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/usr/local/bin/riaps_actor"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="DistributedEstimator DistributedEstimator.json Aggregator --posArg=456 --optArg=&quot;fromCmdLine&quot;"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${env_var:HOME}/riaps_apps/DistributedEstimator"/>
 </launchConfiguration>

--- a/launch examples/riaps run Estimator.launch
+++ b/launch examples/riaps run Estimator.launch
@@ -2,9 +2,9 @@
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramLaunchConfigurationType">
 <mapAttribute key="org.eclipse.debug.core.environmentVariables">
 <mapEntry key="RIAPSAPPS" value="${env_var:HOME}/riaps_apps"/>
-<mapEntry key="RIAPSHOME" value="${env_var:HOME}/.local/riaps"/>
+<mapEntry key="RIAPSHOME" value="${env_var:HOME}/usr/local/riaps"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/.local/bin/riaps_actor"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:HOME}/usr/local/bin/riaps_actor"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="DistributedEstimator DistributedEstimator.json Estimator"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${env_var:HOME}/riaps_apps/DistributedEstimator"/>
 </launchConfiguration>

--- a/launch examples/rpyc_registry.launch
+++ b/launch examples/rpyc_registry.launch
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramLaunchConfigurationType">
 <mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="RIAPSHOME" value="${env_var:HOME}/.local/riaps"/>
+<mapEntry key="RIAPSHOME" value="${env_var:HOME}/usr/local/riaps"/>
 </mapAttribute>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="/usr/local/bin/rpyc_registry.py"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${env_var:HOME}/.local/riaps/etc"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${env_var:HOME}/usr/local/riaps/etc"/>
 </launchConfiguration>


### PR DESCRIPTION
…/.local/riaps --> /usr/local/riaps).