### PR TITLE
Update riaps-deplo.service

### DIFF
--- a/services/armhf/etc/systemd/system/riaps-deplo.service
+++ b/services/armhf/etc/systemd/system/riaps-deplo.service
@@ -4,19 +4,15 @@ Requires=riaps-rm-cgroups.service riaps-rm-quota.service
 
 [Service]
 Type=simple
-RemainAfterExit=yes
 EnvironmentFile=/etc/riaps/systemdenv.conf
 StandardOutput=syslog
 StandardError=inherit
 SyslogIdentifier=RIAPS-DEPLO
 SyslogLevel=info
-ExecStartPre=/bin/sh -c "echo RIAPSHOME=$$RIAPSHOME"
-ExecStartPre=/bin/sh -c "echo RIAPSAPPS=$$RIAPSAPPS"
-ExecStartPre=/bin/sh -c "echo PATH=$$PATH"
-ExecStartPre=/bin/sh -c "echo LD_LIBRARY_PATH=$$LD_LIBRARY_PATH"
 ExecStart=/usr/local/bin/riaps_deplo
+Restart=always
+KillMode=process
+KillSignal=SIGKILL
 
 [Install]
 WantedBy=multi-user.target
-
-


### PR DESCRIPTION
Restart=always enables systemd automatically restarting riaps_deplo if it dies
KillMode=process tells systemd to only kill the main process (riaps_deplo) when stopping or restarting the service
KillSignal=SIGKILL tells systemd to send SIGKILL when stopping the process