### PR TITLE
Added Event.started check to cancel()

### DIFF
--- a/src/riaps/run/timPort.py
+++ b/src/riaps/run/timPort.py
@@ -131,7 +131,8 @@ class TimerThread(threading.Thread):
         '''
         Cancel the sporadic timer
         '''
-        self.waiting.set()
+        if self.started.is_set():
+            self.waiting.set()
     
     def halt(self):
         '''


### PR DESCRIPTION
If cancel is called on an inactive sporadic timer, the next launch() call will pass the ```self.waiting.wait(self.delay)``` immediately, then the delay will be cancelled because self.waiting is still set from the prior call to cancel(). 

Adding this condition to cancel() should fix the issue.