### PR TITLE
capnp executable must be in the path

### DIFF
--- a/src/riaps/gen/target/cpp/tpl/cmake.tpl
+++ b/src/riaps/gen/target/cpp/tpl/cmake.tpl
@@ -52,7 +52,7 @@ add_custom_command(
         OUTPUT  "${CMAKE_SOURCE_DIR}/include/messages/{{appname|lower}}.capnp.c++"
         DEPENDS "${CMAKE_SOURCE_DIR}/{{appname|lower}}.capnp"
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-        COMMAND /opt/riaps/amd64/bin/capnp compile ./{{appname|lower}}.capnp -oc++:./include/messages/
+        COMMAND capnp compile ./{{appname|lower}}.capnp -oc++:./include/messages/
         COMMENT "=== Generating capnp ==="
 )
 


### PR DESCRIPTION
riaps_gen generated cmake expects the capnp executable in the $PATH (instead of absolute path to /opt/riaps...)