### PR TITLE
Formatted exception gets sent up rather than buffering in stderr

### DIFF
--- a/src/riaps/run/comp.py
+++ b/src/riaps/run/comp.py
@@ -174,8 +174,8 @@ class ComponentThread(threading.Thread):
                             self.control.send_pyobj(msg)
                             self.instance.handleDeadline(funcName)
                 except:
-                    traceback.print_exc()
-                    msg = ('exception',)
+                    fmtE = traceback.format_exc()
+                    msg = ('exception',fmtE)
                     self.control.send_pyobj(msg)
         self.logger.info("stopping")
         if hasattr(self.instance,'__destroy__'):


### PR DESCRIPTION
RIAPS component code exceptions are better seen in sequence with their nearest logging statements. Before this change, exception printouts were buffered in stderr and took a long time to appear, if at all. This change formats the exceptions and forces deplo to print it.