### PR TITLE
Formatted exception gets sent up rather than buffering in stderr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,8 @@ script:
 #  api_key:
 #   secure: vVkYyy67ENfj/GcGEsMxU01aVCifbe2yC/+ggjyJbhoFrLlEAvgJrL6yQiPsBCmFAq+SpuJYn6vcPD6YPxaQWpZCjS7mZVdfN5bkWEskwQnxIIhIjQxZGz9FCyaiv9UJKun23+jxeKKZ52dzHhR5vuoNqkR8he8vqQecCPlvR4KUmY/93F3CIU7VY7tpv1oLZiihJm4pli8hswbgeXnIPzloq31hVahqRXShBFq0AdpkTms2W6Cktr6CPYii3EpHV+ft+d6A0qDyJPVF4Hmv8CmNKhudH59qvKv9X7rPw7COSlSVxyLnWmXkKfkjFQtKXh4mm5m9hFkiUGjl30n3ZU23W6IkiZ11k/y1SlpCHOsqQsSisTIFB70mI0exU2UQ5eFJ9DiLOm8i4URF4ZwoPYobZ8CcW1HXxawGXwTi7GWYo5cS8yMjuzQf+Imb05dgU+XCPess/ZIV78NSWTHuRBJFgY33sDhRBnxmg+d//jyALBFRS8n2iTQ2PQMGFPugnp63F6KuDyVLQU1wzuwwP/VOoDMkZXgeyhqzljIId4kScJlc/ucJOmnCWim124V/sUpslpmnu+dYm0PUQ9uXEHmcOheRc87JfMuCMUJKUko1f54FetKfqMYirWnwLlSLn5xNQdja0IXZhdItu//QbHVaiCHwtObNkGiDay6vMy8=
 #  file:
-#   - riaps-pycom-amd64.deb 
+#   - riaps-pycom-amd64.deb
 #   - riaps-pycom-armhf.deb
-#   - riaps-systemd-amd64.deb 
-#   - riaps-systemd-armhf.deb 
 #  skip_cleanup: true
 #  on:
 #    tags: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,13 +22,13 @@ pipeline {
           script {
             def user = 'riaps'
             def repo = 'riaps-pycom'
-            def files = ['riaps-pycom-amd64.deb','riaps-pycom-armhf.deb','riaps-systemd-amd64.deb','riaps-systemd-armhf.deb']
+            def files = ['riaps-pycom-amd64.deb','riaps-pycom-armhf.deb']
             // Create release on GitHub, if it doesn't already exist
             sh "${env.WORKSPACE}/go/bin/github-release release --user ${user} --repo ${repo} --tag ${env.TAG_NAME} --name ${env.TAG_NAME} --pre-release || true"
             // Iterate over artifacts and upload them
             for(int i = 0; i < files.size(); i++){
-              sh "${env.WORKSPACE}/go/bin/github-release upload -R --user ${user} --repo ${repo} --tag ${env.TAG_NAME} --name ${files[i]} --file ${files[i]}" 
-            } 
+              sh "${env.WORKSPACE}/go/bin/github-release upload -R --user ${user} --repo ${repo} --tag ${env.TAG_NAME} --name ${files[i]} --file ${files[i]}"
+            }
           }
         }
       }

--- a/doc/source/requirements.txt
+++ b/doc/source/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==2.1.1
-paramiko==2.4.1
+paramiko==2.6.0
 gitdb2==2.0.5
 GitPython==2.1.11
 rpyc==4.0.2

--- a/doc/source/requirements.txt
+++ b/doc/source/requirements.txt
@@ -3,7 +3,7 @@ paramiko==2.6.0
 gitdb2==2.0.5
 GitPython==2.1.11
 rpyc==4.0.2
-PyYAML==3.12
+PyYAML==5.1.1
 ruamel.std.argparse==0.8.1
 ruamel.yaml==0.15.74
 ruamel.yaml.cmd==0.5.3

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -26,8 +26,8 @@ hiredis >= 0.2.0
 pyzmq >= 16
 pycapnp >= 0.5.12
 netifaces >= 0.10.7
-paramiko >= 2.4.1
-cryptography >= 2.3.1
+paramiko >= 2.6.0
+cryptography >= 2.7
 python-magic >= 0.4.13
 cgroups >= 0.1.0
 cgroupspy >= 0.1.6
@@ -46,6 +46,7 @@ Jinja2 >= 2.10
 pybind11 >= 2.2.4
 toml >= 0.10.0
 pycryptodomex >= 3.7.3 (python3-crypto and python3-keyrings.alt must be removed)
+PyYAML>=5.1.1 (must use --ignore-installed since this is upgrading a distribution package which can not be uninstalled)
 
 use: apt install python3-pip python3-dev libhiredis-dev libcapnp-dev libssl-dev libffi-dev glade python3-gi
 

--- a/src/riaps/deplo/depm.py
+++ b/src/riaps/deplo/depm.py
@@ -53,6 +53,7 @@ from riaps.deplo.procm import ProcessManager
 from riaps.deplo.appdb import AppDbase
 from riaps.utils.ifaces import get_unix_dns_ips
 from riaps.utils.names import actorIdentity
+from riaps.utils.appdesc import AppDescriptor
 
 # Record of the app
 DeploAppRecord = namedtuple('DeploAppRecord', 'model hash file home hosts network')
@@ -399,14 +400,15 @@ class DeploymentManager(threading.Thread):
             raise
         home = ''
         network = { }
+        hosts = []
         try:
             with open(os.path.join(os.path.dirname(modelFileName),const.appDescFile),'r') as f:
-                org = yaml.load(f)
+                org = yaml.load(f, Loader=yaml.Loader)
                 home = org.home
                 network = org.network
                 hosts = org.hosts
         except:
-            pass
+            self.logger.error("Error loading app descriptor:%s",str(sys.exc_info()[1]))
         self.appModels[appName] = DeploAppRecord(hash=fileHash, model=model, 
                                                  file=modelFileName, home=home,
                                                  hosts=hosts, network=network)

--- a/src/riaps/fabfile/README.md
+++ b/src/riaps/fabfile/README.md
@@ -10,7 +10,7 @@ riaps_fab <command_name>
 riaps_fab help
 ```
 
-- To setup a list of host nodes that are to be controlled by the fab command, edit the **/usr/local/riaps/etc/riaps-hosts.conf** and update the **env.hosts** information. Notice that these can be either IP addresses or hostnames.  Also, the hostnames are within double quotes and is a comma separated list without spaces.
+- To setup a list of host nodes that are to be controlled by the fab command, edit the **/etc/riaps/riaps-hosts.conf** and update the **env.hosts** information. Notice that these can be either IP addresses or hostnames.  Also, the hostnames are within double quotes and is a comma separated list without spaces.
 ```
   # This is the hosts configuration file for the RIAPS fabfile
   [RIAPS]
@@ -24,7 +24,7 @@ riaps_fab help
 ```
 riaps_fab <command_name> -H <comma_separated_host_list>
 ```
-- Also, a locally stored riaps-hosts.conf file (or any name) can be used to configure the list of hosts.  This file can be utilized by using the **-f** followed by the absolute path and name of the host file.  This file will be used instead of the default one in **/usr/local/riaps/etc/**
+- Also, a locally stored riaps-hosts.conf file (or any name) can be used to configure the list of hosts.  This file can be utilized by using the **-f** followed by the absolute path and name of the host file.  This file will be used instead of the default one in **/etc/riaps/**
 ```
 riaps_fab <command_name> -f <absolute path and filename of host file>
 ```
@@ -61,7 +61,7 @@ riaps_fab sys.get:riaps_apps/<appname>/log/*,.,true -H <hostname>
 - Running system commands can be done by providing the command desired after the fab command </br>
 ```sys.run:<command>```.  
   - If the command is multiworded, the command should be wrapped in both single and then double quotes.  
-  - Single word commands do not need any quotes. 
+  - Single word commands do not need any quotes.
   - The sudo command is the same.
 ```
 riaps_fab sys.run:'"cat riaps_install_bbb.sh"'

--- a/src/riaps/fabfile/README.md
+++ b/src/riaps/fabfile/README.md
@@ -56,7 +56,7 @@ riaps_fab sys.put <fileName>
 ```
 - Get files from all or specific hosts. This example shows how to grab application saved log files from the application deployment folder (the folder is protected, so sudo=true)
 ```
-riaps_fab sys.get:riaps_apps/<appname>/log/*,.,true -H <hostname>
+riaps_fab sys.get:riaps_apps/<appname>/log/alogfile.log,.,true -H <hostname>
 ```
 - Running system commands can be done by providing the command desired after the fab command </br>
 ```sys.run:<command>```.  

--- a/src/riaps/fabfile/riaps.py
+++ b/src/riaps/fabfile/riaps.py
@@ -186,8 +186,7 @@ def configRouting():
     # Provide appropriate IP address
     sudo('route add default gw ' + hostIP + 'dev eth0')
 
-# Reset the config files with the install files (include /usr/local/riaps/etc
-# and /usr/local/keys folders)
+# Reset the config files with the install files (include /etc/riaps/ folder)
 # MM TODO: consider adding in future release
 #@task
 #def resetConfig():

--- a/src/riaps/fabfile/riaps.py
+++ b/src/riaps/fabfile/riaps.py
@@ -1,7 +1,7 @@
 # Fabric commands for managing RIAPS installs and applications
 from . import deplo
 from .sys import run, sudo, put, get, arch
-from fabric.api import env, task, hosts, local
+from fabric.api import env, task, hosts, local, execute
 from fabric.contrib.files import sed
 import os
 from riaps.consts.defs import *
@@ -14,7 +14,6 @@ packages = [
             'riaps-externals-',
             'riaps-core-',
             'riaps-pycom-',
-            'riaps-systemd-',
             'riaps-timesync-'
             ]
 
@@ -32,15 +31,16 @@ def update():
 @task
 def updateBBBKey():
     """Rekey the BBBs with new generated keys"""
-    key_path = os.path.join(env.riapsHome,"keys/")
-    ssh_pubkey_name = "/home/riaps/.ssh/" + str(const.ctrlPublicKey)
-    ssh_privatekey_name = "/home/riaps/.ssh/" + str(const.ctrlPrivateKey)
-    ssh_cert_name = "/home/riaps/.ssh/" + str(const.ctrlCertificate)
-    ssh_zmqcert_name = "/home/riaps/.ssh/" + str(const.zmqCertificate)
-    riaps_pubkey_name = os.path.join(key_path,str(const.ctrlPublicKey))
-    riaps_privatekey_name = os.path.join(key_path,str(const.ctrlPrivateKey))
-    riaps_cert_name = os.path.join(key_path,str(const.ctrlCertificate))
-    riaps_zmqcert_name = os.path.join(key_path,str(const.zmqCertificate))
+    etc_key_path = "/etc/riaps/"
+    ssh_key_path = "/home/riaps/.ssh/"
+    ssh_pubkey_name = os.path.join(ssh_key_path, str(const.ctrlPublicKey))
+    ssh_privatekey_name = os.path.join(ssh_key_path, str(const.ctrlPrivateKey))
+    ssh_cert_name = os.path.join(ssh_key_path, str(const.ctrlCertificate))
+    ssh_zmqcert_name = os.path.join(ssh_key_path, str(const.zmqCertificate))
+    riaps_pubkey_name = os.path.join(etc_key_path, str(const.ctrlPublicKey))
+    riaps_privatekey_name = os.path.join(etc_key_path, str(const.ctrlPrivateKey))
+    riaps_cert_name = os.path.join(etc_key_path, str(const.ctrlCertificate))
+    riaps_zmqcert_name = os.path.join(etc_key_path, str(const.zmqCertificate))
 
     put(ssh_privatekey_name,'.ssh')
     sudo('cp ' + ssh_privatekey_name + ' ' + riaps_privatekey_name)
@@ -130,8 +130,8 @@ def updateConfig():
     """"Place local riaps.conf on all remote hosts"""
     if(os.path.isfile(os.path.join(os.getcwd(), "riaps.conf"))):
         put('riaps.conf')
-        sudo('cp riaps.conf /usr/local/riaps/etc/')
-        sudo('chown root:root /usr/local/riaps/etc/riaps.conf')
+        sudo('cp riaps.conf /etc/riaps/')
+        sudo('chown root:root /etc/riaps/riaps.conf')
         sudo('rm riaps.conf')
     else:
         print("Local riaps.conf doesn't exist!")
@@ -141,8 +141,8 @@ def updateLogConfig():
     """"Places local riaps-log.conf on all remote hosts"""
     if(os.path.isfile(os.path.join(os.getcwd(), "riaps-log.conf"))):
         put('riaps-log.conf')
-        sudo('cp riaps-log.conf /usr/local/riaps/etc/')
-        sudo('chown root:root /usr/local/riaps/etc/riaps-log.conf')
+        sudo('cp riaps-log.conf /etc/riaps/')
+        sudo('chown root:root /etc/riaps/riaps-log.conf')
         sudo('rm riaps-log.conf')
     else:
         print("Local riaps-log.conf doesn't exist!")
@@ -203,16 +203,16 @@ def configRouting():
 @task
 def securityOff():
     """Turn RIAPS security feature off"""
-    deplo.stop
-    riaps_conf_name = os.path.join(env.riapsHome,"etc/riaps.conf")
+    execute(deplo.stop)
+    riaps_conf_name = "/etc/riaps/riaps.conf"
     sed(riaps_conf_name, 'security = on', 'security = off', use_sudo=True)
-    deplo.start
+    execute(deplo.start)
 
 # Turn on RIAPS security feature
 @task
 def securityOn():
     """Turn RIAPS security feature on"""
-    deplo.stop
-    riaps_conf_name = os.path.join(env.riapsHome,"etc/riaps.conf")
+    execute(deplo.stop)
+    riaps_conf_name = "/etc/riaps/riaps.conf"
     sed(riaps_conf_name, 'security = off', 'security = on', use_sudo=True)
-    deplo.start
+    execute(deplo.start)

--- a/src/riaps/run/actor.py
+++ b/src/riaps/run/actor.py
@@ -28,6 +28,7 @@ import yaml
 from czmq import Zsys
 from riaps.utils import spdlog_setup
 from riaps.utils.config import Config
+from riaps.utils.appdesc import AppDescriptor
 import zmq.auth
 from zmq.auth.thread import ThreadAuthenticator
 
@@ -83,7 +84,7 @@ class Actor(object):
             hosts = ['127.0.0.1']
             try:
                 with open(const.appDescFile,'r') as f:
-                    content = yaml.load(f)
+                    content = yaml.load(f, Loader=yaml.Loader)
                     hosts += content.hosts
             except:
                 pass

--- a/src/riaps/run/comp.py
+++ b/src/riaps/run/comp.py
@@ -174,8 +174,8 @@ class ComponentThread(threading.Thread):
                             self.control.send_pyobj(msg)
                             self.instance.handleDeadline(funcName)
                 except:
-                    traceback.print_exc()
-                    msg = ('exception',)
+                    fmtE = traceback.format_exc()
+                    msg = ('exception',fmtE)
                     self.control.send_pyobj(msg)
         self.logger.info("stopping")
         if hasattr(self.instance,'__destroy__'):

--- a/src/riaps/run/device.py
+++ b/src/riaps/run/device.py
@@ -16,6 +16,7 @@ from riaps.proto import disco_capnp
 from riaps.consts.defs import *
 from riaps.utils.ifaces import getNetworkInterfaces
 from riaps.utils.config import Config
+from riaps.utils.appdesc import AppDescriptor
 import getopt
 import logging
 from builtins import int, str
@@ -96,7 +97,7 @@ class Device(Actor):
             hosts = ['127.0.0.1']
             try:
                 with open(const.appDescFile,'r') as f:
-                    content = yaml.load(f)
+                    content = yaml.load(f, Loader=yaml.Loader)
                     hosts += content.hosts
             except:
                 pass

--- a/src/riaps/utils/appdesc.py
+++ b/src/riaps/utils/appdesc.py
@@ -5,8 +5,9 @@ Created on Oct 29, 2018
 
 @author: riaps
 '''
+import yaml
 
-class AppDescriptor(object):
+class AppDescriptor(yaml.YAMLObject):
     '''
     RIAPS app origin - 'signature file
     url = URL of the repo (or local folder) the app is coming from
@@ -17,6 +18,7 @@ class AppDescriptor(object):
     hosts = hosts participating in the app
     network = network access control for nodes, (ip|'[]') => [] | [ ('dns' | ip) ]+  
     '''
+    yaml_loader = yaml.SafeLoader
     def __init__(self,url,host,mac,sha,home,hosts,network):
         self.url = url
         self.host = host
@@ -25,7 +27,9 @@ class AppDescriptor(object):
         self.home = home
         self.hosts = hosts
         self.network = network
+        
     def __repr__(self):
         return "%s(url=%r, host=%r, mac=%r, sha=%r, home=%r, hosts=%r, network=%r)" % (
              self.__class__.__name__, self.url, self.host, self.mac, self.sha, self.home,
              self.hosts, self.network)
+


### PR DESCRIPTION
RIAPS component code exceptions are better seen in sequence with their nearest logging statements. Before this change, exception printouts were buffered in stderr and took a long time to appear, if at all. This change formats the exceptions and forces deplo to print it.