### PR TITLE
Pass component exceptions up to deplo to be printed

### DIFF
--- a/src/riaps/run/comp.py
+++ b/src/riaps/run/comp.py
@@ -174,8 +174,8 @@ class ComponentThread(threading.Thread):
                             self.control.send_pyobj(msg)
                             self.instance.handleDeadline(funcName)
                 except:
-                    traceback.print_exc()
-                    msg = ('exception',)
+                    fmtE = traceback.format_exc()
+                    msg = ('exception',fmtE,)
                     self.control.send_pyobj(msg)
         self.logger.info("stopping")
         if hasattr(self.instance,'__destroy__'):


### PR DESCRIPTION
Component exceptions are currently buffered in stderr, and don't get printed alongside their proximal logging statements. This change formats them and passes them up to be printed immediately.