### PR TITLE
Add c command to riaps_ctrl CLI

### DIFF
--- a/src/riaps/ctrl/ctrlcli.py
+++ b/src/riaps/ctrl/ctrlcli.py
@@ -76,7 +76,6 @@ class ControlCLIClient(object):
 
         def do_c(self, arg):
             '''Wait until listed clients are connected: c IPADDR1 [IPADDR2 ...]'''
-            # numExpecting = int(arg) if arg else 1
             expectedClients = set(arg.split(', '))
             while True:
                 clients = set(self.parent.getClients())

--- a/src/riaps/ctrl/ctrlcli.py
+++ b/src/riaps/ctrl/ctrlcli.py
@@ -73,7 +73,18 @@ class ControlCLIClient(object):
         def __init__(self,parent):
             super(parent.CtrlCmdShell, self).__init__()
             self.parent = parent
-            
+
+        def do_c(self, arg):
+            '''Wait until listed clients are connected: c IPADDR1 [IPADDR2 ...]'''
+            # numExpecting = int(arg) if arg else 1
+            expectedClients = set(arg.split(', '))
+            while True:
+                clients = set(self.parent.getClients())
+                if expectedClients.issubset(clients):
+                    break
+                self.stdout.write(f"Waiting for: {expectedClients not in clients}\n")
+                time.sleep(1)
+
         def do_f(self,arg):
             '''Select app folder: f path'''
             self.parent.cmdSelectFolder(arg)
@@ -218,6 +229,12 @@ class ControlCLIClient(object):
         Clears the app entry.
         '''
         self.appName = ''
+    
+    def cmdNumClient(self):
+        '''
+        Gets number of connected clients
+        '''
+        return self.controller.numClients()
           
     def cmdSelectDepl(self,fileName):
         if fileName != None:


### PR DESCRIPTION
Adds command to riaps_ctrl scripting language..
Usage: `c <IP address of node> [<IP address of node>...]`
Compares the space-separated list of clients to those logged into the control service, once per second.
Those not yet present are printed out. Loops indefinitely. 