### PR TITLE
Set RIAPS* envvars for SSH sessions

### DIFF
--- a/DEBIAN/sysfiles/etc/ssh/sshd_config.d/riaps-env.conf
+++ b/DEBIAN/sysfiles/etc/ssh/sshd_config.d/riaps-env.conf
@@ -1,0 +1,2 @@
+Match User riaps
+  SetEnv RIAPSHOME=/usr/local/riaps RIAPSAPPS=/home/riaps/riaps_apps


### PR DESCRIPTION
Commands executed over SSH such as `ssh <host> <cmd>` or those via Fabric occur in non-login non-interactive shells, which don't hit any of our .bash* or .profile* config files. This config sets RIAPSHOME and RIAPSAPPS for SSH sessions matching the riaps user.